### PR TITLE
Implement copying files

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -270,7 +270,7 @@ class Client
     }
 
     /**
-     * Copy a file
+     * Copy a file.
      *
      * $options:
      * required BucketName or BucketId the source bucket
@@ -279,9 +279,11 @@ class Client
      * optional destinationBucketId or destinationBucketName, the destination bucket
      *
      * @param array $options
-     * @return File
+     *
      * @throws B2Exception
      * @throws GuzzleException
+     *
+     * @return File
      */
     public function copy(array $options)
     {
@@ -300,7 +302,7 @@ class Client
 
         $json = [
             'sourceFileId' => $sourceFileId,
-            'fileName' => $options['SaveAs'],
+            'fileName'     => $options['SaveAs'],
         ];
         if (isset($options['destinationBucketId'])) {
             $json['destinationBucketId'] = $options['destinationBucketId'];
@@ -547,16 +549,17 @@ class Client
      * @param $bucketId
      * @param $fileName
      *
-     * @return string|bool The file's id, or false if not found
      * @throws B2Exception
      * @throws GuzzleException
+     *
+     * @return string|bool The file's id, or false if not found
      */
     protected function getFileIdFromBucketIdAndFileName($bucketId, $fileName)
     {
         $response = $this->sendAuthorizedRequest('POST', 'b2_list_file_names', [
-            'bucketId' => $bucketId,
+            'bucketId'      => $bucketId,
             'startFileName' => $fileName,
-            'maxFileCount' => 1,
+            'maxFileCount'  => 1,
         ]);
 
         return count($response['files']) === 1 ? $response['files'][0]['fileId'] : false;

--- a/src/Client.php
+++ b/src/Client.php
@@ -270,6 +270,55 @@ class Client
     }
 
     /**
+     * Copy a file
+     *
+     * $options:
+     * required BucketName or BucketId the source bucket
+     * required FileName the file to copy
+     * required SaveAs the path and file name to save to
+     * optional destinationBucketId or destinationBucketName, the destination bucket
+     *
+     * @param array $options
+     * @return File
+     * @throws B2Exception
+     * @throws GuzzleException
+     */
+    public function copy(array $options)
+    {
+        $options['FileName'] = ltrim($options['FileName'], '/');
+        $options['SaveAs'] = ltrim($options['SaveAs'], '/');
+
+        if (!isset($options['destinationBucketId']) && isset($options['destinationBucketName'])) {
+            $options['destinationBucketId'] = $this->getBucketIdFromName($options['destinationBucketName']);
+        }
+
+        if (!isset($options['BucketId']) && isset($options['BucketName'])) {
+            $options['BucketId'] = $this->getBucketIdFromName($options['BucketName']);
+        }
+
+        $sourceFileId = $this->getFileIdFromBucketIdAndFileName($options['BucketId'], $options['FileName']);
+
+        $json = [
+            'sourceFileId' => $sourceFileId,
+            'fileName' => $options['SaveAs'],
+        ];
+        if (isset($options['destinationBucketId'])) {
+            $json['destinationBucketId'] = $options['destinationBucketId'];
+        }
+
+        $response = $this->sendAuthorizedRequest('POST', 'b2_copy_file', $json);
+
+        return new File(
+            $response['fileId'],
+            $response['fileName'],
+            $response['contentSha1'],
+            $response['contentLength'],
+            $response['contentType'],
+            $response['fileInfo']
+        );
+    }
+
+    /**
      * Retrieve a collection of File objects representing the files stored inside a bucket.
      *
      * @param array $options
@@ -492,6 +541,25 @@ class Client
                 return $file->getId();
             }
         }
+    }
+
+    /**
+     * @param $bucketId
+     * @param $fileName
+     *
+     * @return string|bool The file's id, or false if not found
+     * @throws B2Exception
+     * @throws GuzzleException
+     */
+    protected function getFileIdFromBucketIdAndFileName($bucketId, $fileName)
+    {
+        $response = $this->sendAuthorizedRequest('POST', 'b2_list_file_names', [
+            'bucketId' => $bucketId,
+            'startFileName' => $fileName,
+            'maxFileCount' => 1,
+        ]);
+
+        return count($response['files']) === 1 ? $response['files'][0]['fileId'] : false;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -502,7 +502,7 @@ class ClientTest extends TestCase
         $actual = $client->copy([
             'BucketId' => 'sourceBucketId',
             'FileName' => 'sourceFileName',
-            'SaveAs' => 'destinationFileName',
+            'SaveAs'   => 'destinationFileName',
         ]);
 
         $this->assertInstanceOf('BackblazeB2\File', $actual);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -489,6 +489,26 @@ class ClientTest extends TestCase
         ]);
     }
 
+    public function testCopyFile()
+    {
+        $guzzle = $this->buildGuzzleFromResponses([
+            $this->buildResponseFromStub(200, [], 'authorize_account.json'),
+            $this->buildResponseFromStub(200, [], 'list_files_page1.json'),
+            $this->buildResponseFromStub(200, [], 'copy_file.json'),
+        ]);
+
+        $client = new Client('testId', 'testKey', ['client' => $guzzle]);
+
+        $actual = $client->copy([
+            'BucketId' => 'sourceBucketId',
+            'FileName' => 'sourceFileName',
+            'SaveAs' => 'destinationFileName',
+        ]);
+
+        $this->assertInstanceOf('BackblazeB2\File', $actual);
+        $this->assertEquals('4_z4c2b953461da9c825f260e1b_f1114dbf5bg9707e8_d20160206_m012226_c001_v1111017_t0010', $actual->getId());
+    }
+
     public function testDeleteFile()
     {
         $guzzle = $this->buildGuzzleFromResponses([

--- a/tests/responses/copy_file.json
+++ b/tests/responses/copy_file.json
@@ -1,0 +1,14 @@
+{
+  "accountId": "accountId",
+  "bucketId": "bucketId",
+  "contentLength": 20,
+  "contentSha1": "bc77b0349d325be71ed2ca26d5e68173210e9e18",
+  "contentType": "application/octet-stream",
+  "fileId": "4_z4c2b953461da9c825f260e1b_f1114dbf5bg9707e8_d20160206_m012226_c001_v1111017_t0010",
+  "fileInfo": {
+    "src_last_modified_millis": "1454721688784"
+  },
+  "action": "upload",
+  "uploadTimestamp": "1465983870000",
+  "fileName": "Test file.bin"
+}

--- a/tests/responses/list_files_single.json
+++ b/tests/responses/list_files_single.json
@@ -1,0 +1,18 @@
+{
+  "files": [
+    {
+      "accountId": "accountId",
+      "bucketId": "bucketId",
+      "contentLength": 20,
+      "contentSha1": "bc77b0349d325be71ed2ca26d5e68173210e9e18",
+      "contentType": "application/octet-stream",
+      "fileId": "4_z4c2b953461da9c825f260e1b_f1114dbf5bg9707e8_d20160206_m012226_c001_v1111017_t0010",
+      "fileInfo": {
+        "src_last_modified_millis": "1454721688784"
+      },
+      "action": "upload",
+      "uploadTimestamp": "1465983870000",
+      "fileName": "Test file.bin"
+    }
+  ]
+}


### PR DESCRIPTION
The b2 API supports copying files through the endpoint b2_copy_file.

The options array supports BucketName or BucketId, FileName, SaveAs, and
optionally destinationBucketId or destinationBucketName.

As a bonus, there is now getFileIdFromBucketIdAndFileName, a faster
way to retrieve FileIds for single files.